### PR TITLE
Dynamic two column section

### DIFF
--- a/about.html
+++ b/about.html
@@ -56,12 +56,8 @@
           ></div>
         </div>
         <div class="content-wrapper">
-          <div class="two-column-list">
-            <div class="column-left">
-              <h4 class="fade-left" data-i18n="about-experience-headline"></h4>
-            </div>
-            <div class="column-right" id="experience-list"></div>
-          </div>
+          <!-- Dynamischer Block für Berufserfahrung -->
+          <div id="experience-section"></div>
         </div>
       </section>
     </main>

--- a/js/about.js
+++ b/js/about.js
@@ -1,5 +1,6 @@
 import { setLanguage, currentLang, translations } from "./i18n.js";
 import { initNav } from "./nav.js";
+import { createTwoColumnSection } from "./layout.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await setLanguage(localStorage.getItem("lang") || "de");
@@ -17,15 +18,14 @@ document.addEventListener("DOMContentLoaded", async () => {
 });
 
 async function loadExperience() {
-  const container = document.getElementById("experience-list");
+  const container = document.getElementById("experience-section");
   if (!container) return;
 
   try {
     const res = await fetch("data/about.json");
     const data = await res.json();
-    container.innerHTML = "";
 
-    data.experience.forEach((job) => {
+    const entries = data.experience.map((job) => {
       const wrapper = document.createElement("div");
       wrapper.className = "experience-entry fade-right";
 
@@ -33,7 +33,6 @@ async function loadExperience() {
       title.className = "job-title";
       title.textContent = translations[job.title]?.[currentLang] || job.title;
 
-      // Meta-Wrapper
       const metaWrapper = document.createElement("div");
       metaWrapper.className = "job-meta";
 
@@ -47,7 +46,6 @@ async function loadExperience() {
       period.textContent =
         translations[job.period]?.[currentLang] || job.period;
 
-      // company + period in metaWrapper packen
       metaWrapper.append(company, period);
 
       const text = document.createElement("div");
@@ -55,8 +53,19 @@ async function loadExperience() {
       text.textContent = translations[job.text]?.[currentLang] || job.text;
 
       wrapper.append(title, metaWrapper, text);
-      container.appendChild(wrapper);
+      return wrapper;
     });
+
+    container.innerHTML = "";
+    container.appendChild(
+      createTwoColumnSection(
+        "about-experience-headline",
+        entries,
+        translations,
+        currentLang,
+        "experience-list"
+      )
+    );
   } catch (err) {
     console.error("Fehler beim Laden der Erfahrung:", err);
   }

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,0 +1,27 @@
+export function createTwoColumnSection(leftKey, rightElements, translations, currentLang, rightId) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'two-column-list';
+
+  const leftCol = document.createElement('div');
+  leftCol.className = 'column-left';
+
+  const headline = document.createElement('h4');
+  headline.className = 'fade-left';
+  headline.textContent = translations[leftKey]?.[currentLang] || leftKey;
+  leftCol.appendChild(headline);
+
+  const rightCol = document.createElement('div');
+  rightCol.className = 'column-right';
+  if (rightId) {
+    rightCol.id = rightId;
+  }
+
+  if (Array.isArray(rightElements)) {
+    rightElements.forEach(el => rightCol.appendChild(el));
+  } else if (rightElements) {
+    rightCol.appendChild(rightElements);
+  }
+
+  wrapper.append(leftCol, rightCol);
+  return wrapper;
+}


### PR DESCRIPTION
## Summary
- build an experience block in `about.html` dynamically
- add helper `createTwoColumnSection` for a reusable layout
- refactor `about.js` to render experience list via the new helper

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687cd266284083329b95d805b7e3468e