### PR TITLE
Add scroll-triggered fade animations

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,7 +12,7 @@
     />
   </head>
   <body>
-    <header>
+    <header class="fade-top">
       <nav>
         <a class="nav-brand" href="index.html">
           <div class="logo"><img src="./assets/images/logo/Logo.svg" /></div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -527,9 +527,15 @@ button:hover {
     transition: all 0.6s ease-out;
 }
 
+.fade-top {
+    opacity: 0;
+    transform: translateY(-50px);
+    transition: all 0.6s ease-out;
+}
+
 .in-view {
     opacity: 1 !important;
-    transform: translateX(0) !important;
+    transform: translate(0) !important;
 }
 
 /* === TABLET NAV === */

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
   <body class="scroll-snap">
     <main>
-      <header id="site-header" class="transparent">
+      <header id="site-header" class="transparent fade-top">
         <nav>
           <a class="nav-brand" href="index.html#home">
             <div class="logo"><img src="./assets/images/logo/Logo.svg" /></div>

--- a/js/about.js
+++ b/js/about.js
@@ -1,6 +1,7 @@
 import { setLanguage, currentLang, translations } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { createTwoColumnSection } from "./layout.js";
+import { initFadeAnimations } from "./animations.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await setLanguage(localStorage.getItem("lang") || "de");
@@ -10,11 +11,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     ?.addEventListener("click", async () => {
       const newLang = currentLang === "de" ? "en" : "de";
       await setLanguage(newLang);
-      loadExperience(); // Erfahrungseinträge neu übersetzen
+      await loadExperience(); // Erfahrungseinträge neu übersetzen
     });
 
   initNav();
-  loadExperience();
+  await loadExperience();
+  initFadeAnimations();
 });
 
 async function loadExperience() {
@@ -66,6 +68,7 @@ async function loadExperience() {
         "experience-list"
       )
     );
+    initFadeAnimations();
   } catch (err) {
     console.error("Fehler beim Laden der Erfahrung:", err);
   }

--- a/js/animations.js
+++ b/js/animations.js
@@ -1,0 +1,19 @@
+export function initFadeAnimations() {
+  const elements = document.querySelectorAll(
+    '.fade-left, .fade-right, .fade-top'
+  );
+  const observer = new IntersectionObserver(
+    entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('in-view');
+        } else {
+          entry.target.classList.remove('in-view');
+        }
+      });
+    },
+    { threshold: 0.1 }
+  );
+
+  elements.forEach(el => observer.observe(el));
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,6 @@
 import { setLanguage, currentLang, translations } from "./i18n.js";
 import { initNav, highlightProjectButtons } from "./nav.js";
+import { initFadeAnimations } from "./animations.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await setLanguage(localStorage.getItem("lang") || "de");
@@ -9,20 +10,22 @@ document.addEventListener("DOMContentLoaded", async () => {
     ?.addEventListener("click", async () => {
       const newLang = currentLang === "de" ? "en" : "de";
       await setLanguage(newLang);
-      renderChipsAndProjects(); // Nach Sprachwechsel
+      await renderChipsAndProjects(); // Nach Sprachwechsel
+      initFadeAnimations();
     });
 
   initNav(highlightProjectButtons);
-  renderChipsAndProjects();
+  await renderChipsAndProjects();
+  initFadeAnimations();
   setupScrollAndNavigation();
   window.history.scrollRestoration = "manual";
   setTimeout(() => window.scrollTo(0, 0), 0);
 });
 
-function renderChipsAndProjects() {
+async function renderChipsAndProjects() {
   renderChipsFromI18n({ prefix: "skills", containerId: "skillsContainer" });
   renderChipsFromI18n({ prefix: "tools", containerId: "toolsContainer" });
-  renderProjects();
+  await renderProjects();
 }
 
 // === Chips ===


### PR DESCRIPTION
## Summary
- add `animations.js` module to handle fade-in transitions when elements enter the viewport
- integrate animation setup in `index.js` and `about.js`
- implement a new `fade-top` animation for the header

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687cd89091d48332b326715c8d248225