### PR TITLE
Implement dynamic header inclusion

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,36 +12,6 @@
     />
   </head>
   <body>
-    <header class="fade-top">
-      <nav>
-        <a class="nav-brand" href="index.html">
-          <div class="logo"><img src="./assets/images/logo/Logo.svg" /></div>
-          <div class="link">Tim <br />Schedlbauer</div>
-        </a>
-
-        <button class="burger" id="burger-toggle" aria-label="Menü öffnen">
-          &#9776;
-        </button>
-
-        <div class="nav-menu" id="nav-menu">
-          <a
-            class="nav-link js-to-projects"
-            href="index.html#projects"
-            data-i18n="projects"
-          ></a>
-          <a class="nav-link active" href="about.html" data-i18n="about"></a>
-          <a class="nav-link" data-i18n="contact"></a>
-          <button
-            id="lang-toggle"
-            class="lang-btn"
-            aria-label="Sprache wechseln"
-          >
-            <span class="lang-option" data-lang="de">DE</span> /
-            <span class="lang-option" data-lang="en">EN</span>
-          </button>
-        </div>
-      </nav>
-    </header>
 
     <main>
       <section class="smooth-wrapper" id="luxy">

--- a/header.html
+++ b/header.html
@@ -1,0 +1,18 @@
+<header class="fade-top">
+  <nav>
+    <a class="nav-brand" href="index.html">
+      <div class="logo"><img src="./assets/images/logo/Logo.svg" /></div>
+      <div class="link">Tim <br />Schedlbauer</div>
+    </a>
+    <button class="burger" id="burger-toggle" aria-label="Menü öffnen">&#9776;</button>
+    <div class="nav-menu" id="nav-menu">
+      <a class="nav-link js-to-projects" href="index.html#projects" data-i18n="projects"></a>
+      <a class="nav-link" href="about.html" data-i18n="about"></a>
+      <a class="nav-link" data-i18n="contact"></a>
+      <button id="lang-toggle" class="lang-btn" aria-label="Sprache wechseln">
+        <span class="lang-option" data-lang="de">DE</span> /
+        <span class="lang-option" data-lang="en">EN</span>
+      </button>
+    </div>
+  </nav>
+</header>

--- a/index.html
+++ b/index.html
@@ -14,32 +14,6 @@
 
   <body class="scroll-snap">
     <main>
-      <header id="site-header" class="transparent fade-top">
-        <nav>
-          <a class="nav-brand" href="index.html#home">
-            <div class="logo"><img src="./assets/images/logo/Logo.svg" /></div>
-            <div class="link">Tim <br />Schedlbauer</div>
-          </a>
-
-          <button class="burger" id="burger-toggle" aria-label="Menü öffnen">
-            &#9776;
-          </button>
-
-          <div class="nav-menu" id="nav-menu">
-            <a class="nav-link js-to-projects" data-i18n="projects"></a>
-            <a class="nav-link" href="about.html" data-i18n="about"></a>
-            <a class="nav-link" data-i18n="contact"></a>
-            <button
-              id="lang-toggle"
-              class="lang-btn"
-              aria-label="Sprache wechseln"
-            >
-              <span class="lang-option" data-lang="de">DE</span> /
-              <span class="lang-option" data-lang="en">EN</span>
-            </button>
-          </div>
-        </nav>
-      </header>
 
       <section class="section" id="home">
         <div class="max-width">

--- a/js/about.js
+++ b/js/about.js
@@ -2,8 +2,10 @@ import { setLanguage, currentLang, translations } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { createTwoColumnSection } from "./layout.js";
 import { initFadeAnimations } from "./animations.js";
+import { loadHeader } from "./header.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
+  await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
   document

--- a/js/header.js
+++ b/js/header.js
@@ -1,0 +1,20 @@
+export async function loadHeader(options = {}) {
+  const { transparent = false, indexPage = false } = options;
+  try {
+    const res = await fetch('header.html');
+    const html = await res.text();
+    const temp = document.createElement('div');
+    temp.innerHTML = html.trim();
+    const header = temp.firstElementChild;
+    if (transparent) header.classList.add('transparent');
+    if (indexPage) {
+      const brand = header.querySelector('.nav-brand');
+      brand?.setAttribute('href', 'index.html#home');
+      const projects = header.querySelector('.js-to-projects');
+      projects?.removeAttribute('href');
+    }
+    document.body.prepend(header);
+  } catch (err) {
+    console.error('Header loading failed', err);
+  }
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,8 +1,10 @@
 import { setLanguage, currentLang, translations } from "./i18n.js";
 import { initNav, highlightProjectButtons } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
+import { loadHeader } from "./header.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
+  await loadHeader({ transparent: true, indexPage: true });
   await setLanguage(localStorage.getItem("lang") || "de");
 
   document


### PR DESCRIPTION
## Summary
- add shared `header.html` with navigation markup
- create `loadHeader` helper to fetch and insert header
- load the header dynamically in `index.js` and `about.js`
- remove inline header markup from `index.html` and `about.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ce7ff6f4c8332aa6574b194255cd3