### PR TITLE
Add language toggle helper and dynamic project sections

### DIFF
--- a/js/about.js
+++ b/js/about.js
@@ -1,4 +1,4 @@
-import { setLanguage, currentLang, translations } from "./i18n.js";
+import { setLanguage, currentLang, translations, initLangToggle } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { createTwoColumnSection } from "./layout.js";
 import { initFadeAnimations } from "./animations.js";
@@ -8,13 +8,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  document
-    .getElementById("lang-toggle")
-    ?.addEventListener("click", async () => {
-      const newLang = currentLang === "de" ? "en" : "de";
-      await setLanguage(newLang);
-      await loadExperience(); // Erfahrungseinträge neu übersetzen
-    });
+  initLangToggle(async () => {
+    await loadExperience(); // Erfahrungseinträge neu übersetzen
+  });
 
   initNav();
   await loadExperience();

--- a/js/archive.js
+++ b/js/archive.js
@@ -1,4 +1,4 @@
-import { setLanguage, currentLang } from "./i18n.js";
+import { setLanguage, initLangToggle, currentLang } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
@@ -7,10 +7,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  document.getElementById("lang-toggle")?.addEventListener("click", async () => {
-    const newLang = currentLang === "de" ? "en" : "de";
-    await setLanguage(newLang);
-  });
+  initLangToggle();
 
   initNav();
   initFadeAnimations();

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -40,3 +40,11 @@ export async function setLanguage(lang) {
   localStorage.setItem("lang", lang);
   updateLangButtonUI();
 }
+
+export function initLangToggle(callback) {
+  document.getElementById("lang-toggle")?.addEventListener("click", async () => {
+    const newLang = currentLang === "de" ? "en" : "de";
+    await setLanguage(newLang);
+    if (typeof callback === "function") callback();
+  });
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,4 @@
-import { setLanguage, currentLang, translations } from "./i18n.js";
+import { setLanguage, currentLang, translations, initLangToggle } from "./i18n.js";
 import { initNav, highlightProjectButtons } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
@@ -7,14 +7,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader({ transparent: true, indexPage: true });
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  document
-    .getElementById("lang-toggle")
-    ?.addEventListener("click", async () => {
-      const newLang = currentLang === "de" ? "en" : "de";
-      await setLanguage(newLang);
-      await renderChipsAndProjects(); // Nach Sprachwechsel
-      initFadeAnimations();
-    });
+  initLangToggle(async () => {
+    await renderChipsAndProjects();
+    initFadeAnimations();
+  });
 
   initNav(highlightProjectButtons);
   await renderChipsAndProjects();

--- a/js/layout.js
+++ b/js/layout.js
@@ -25,3 +25,70 @@ export function createTwoColumnSection(leftKey, rightElements, translations, cur
   wrapper.append(leftCol, rightCol);
   return wrapper;
 }
+
+export function createDesignProcessSection(translations, currentLang) {
+  const phases = [
+    {
+      title: 'designprocess_title1',
+      methods: [
+        'designprocess_analyse_method1',
+        'designprocess_analyse_method2',
+        'designprocess_analyse_method3',
+        'designprocess_analyse_method4',
+        'designprocess_analyse_method5'
+      ]
+    },
+    {
+      title: 'designprocess_title2',
+      methods: [
+        'designprocess_concept_method1',
+        'designprocess_concept_method2',
+        'designprocess_concept_method3',
+        'designprocess_concept_method4',
+        'designprocess_concept_method5'
+      ]
+    },
+    {
+      title: 'designprocess_title3',
+      methods: [
+        'designprocess_design_method1',
+        'designprocess_design_method2',
+        'designprocess_design_method3',
+        'designprocess_design_method4',
+        'designprocess_design_method5',
+        'designprocess_design_method6',
+        'designprocess_design_method7',
+        'designprocess_design_method8',
+        'designprocess_design_method9'
+      ]
+    },
+    {
+      title: 'designprocess_title4',
+      methods: ['designprocess_testing_method1']
+    }
+  ];
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'project-details';
+
+  phases.forEach(phase => {
+    const list = document.createElement('div');
+    list.className = 'project-details-list';
+
+    const h4 = document.createElement('h4');
+    h4.textContent = translations[phase.title]?.[currentLang] || phase.title;
+
+    const items = document.createElement('div');
+    items.className = 'project-details-list-items';
+    phase.methods.forEach(key => {
+      const span = document.createElement('span');
+      span.textContent = translations[key]?.[currentLang] || key;
+      items.appendChild(span);
+    });
+
+    list.append(h4, items);
+    wrapper.appendChild(list);
+  });
+
+  return wrapper;
+}

--- a/js/project1.js
+++ b/js/project1.js
@@ -1,19 +1,51 @@
-import { setLanguage, currentLang } from "./i18n.js";
+import { setLanguage, currentLang, translations, initLangToggle } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
+import { createTwoColumnSection, createDesignProcessSection } from "./layout.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  document
-    .getElementById("lang-toggle")
-    ?.addEventListener("click", async () => {
-      const newLang = currentLang === "de" ? "en" : "de";
-      await setLanguage(newLang);
-    });
+  initLangToggle(renderSections);
 
   initNav();
+  renderSections();
   initFadeAnimations();
 });
+
+function renderSections() {
+  const container = document.querySelector(".content-wrapper");
+  if (!container) return;
+
+  container.querySelectorAll(".dynamic-section").forEach((el) => el.remove());
+
+  const sections = [
+    { type: "twoColumn", left: "project1_sec1_title", text: "project1_sec1_text" },
+    { type: "video", src: "./assets/videos/TimSchedlbauer_Portfoliovideo_Scene1.webm" },
+    { type: "twoColumn", left: "project1_sec2_title", text: "project1_sec2_text" },
+    { type: "designprocess" }
+  ];
+
+  sections.forEach((sec) => {
+    let el;
+    if (sec.type === "twoColumn") {
+      const p = document.createElement("p");
+      p.textContent = translations[sec.text]?.[currentLang] || sec.text;
+      el = createTwoColumnSection(sec.left, [p], translations, currentLang);
+    } else if (sec.type === "video") {
+      const vid = document.createElement("video");
+      vid.src = sec.src;
+      vid.controls = true;
+      el = document.createElement("div");
+      el.appendChild(vid);
+    } else if (sec.type === "designprocess") {
+      el = createDesignProcessSection(translations, currentLang);
+    }
+    if (el) {
+      el.classList.add("dynamic-section");
+      container.appendChild(el);
+    }
+  });
+}

--- a/js/project2.js
+++ b/js/project2.js
@@ -1,4 +1,4 @@
-import { setLanguage, currentLang } from "./i18n.js";
+import { setLanguage, initLangToggle, currentLang } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
@@ -7,10 +7,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  document.getElementById("lang-toggle")?.addEventListener("click", async () => {
-    const newLang = currentLang === "de" ? "en" : "de";
-    await setLanguage(newLang);
-  });
+  initLangToggle();
 
   initNav();
   initFadeAnimations();

--- a/js/project3.js
+++ b/js/project3.js
@@ -1,4 +1,4 @@
-import { setLanguage, currentLang } from "./i18n.js";
+import { setLanguage, initLangToggle, currentLang } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
@@ -7,10 +7,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  document.getElementById("lang-toggle")?.addEventListener("click", async () => {
-    const newLang = currentLang === "de" ? "en" : "de";
-    await setLanguage(newLang);
-  });
+  initLangToggle();
 
   initNav();
   initFadeAnimations();

--- a/lang/lang.json
+++ b/lang/lang.json
@@ -103,6 +103,16 @@
     "de": "Der Fischer Profil Showroom ist eine innovative, virtuelle 3D Plattform zur interaktiven Präsentation von Dach- und Fassadensystemen. Entwickelt als Web-App auf Basis des VISHOW-Systems von Solid White, ermöglicht er Architekten, Kunden und Vertriebsmitarbeitern eine intuitive Produktkonfiguration und -visualisierung.",
     "en": "The Fischer Profil Showroom is an innovative, virtual 3D platform for the interactive presentation of roof and facade systems. Developed as a web app based on Solid White's VISHOW-System, it enables architects, customers and sales staff to configure and visualize products intuitively."
   },
+  "project1_sec1_title": { "de": "Herausforderung", "en": "Challenge" },
+  "project1_sec1_text": {
+    "de": "Kurzer Text zur Herausforderung des Projekts.",
+    "en": "Short text describing the project's challenge."
+  },
+  "project1_sec2_title": { "de": "L\u00f6sung", "en": "Solution" },
+  "project1_sec2_text": {
+    "de": "Kurzer Text zur entwickelten L\u00f6sung.",
+    "en": "Short text about the developed solution."
+  },
   "project2_text": {
     "de": "Ein für WebGL entwickeltes 3D-Spiel, das speziell für Remote-Teams konzipiert wurde, um Teambuilding durch teambasierte Mechaniken zu fördern und zu verbessern. Das Projekt basierte auf \u201eVISPA Workshops\u201c, einem kollaborativen 3D-Ideation- und Workshop-Tool, welches mit einem starken Fokus auf Gamification weiterentwickelt wurde.",
     "en": "A 3D game developed for WebGL, specifically designed for remote teams to promote and improve team building through team-based mechanics. The project was based on \u201cVISPA Workshops\u201d, a collaborative 3D ideation and workshop tool, which was further developed with a strong focus on gamification."


### PR DESCRIPTION
## Summary
- add `initLangToggle` helper to i18n utilities
- build design process generator in `layout.js`
- create dynamic section renderer for project1
- update project scripts to use modular language toggle
- add placeholder translation keys for new project1 sections

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e56a9dab08332a7293bef3b74e91b