### PR TITLE
Dynamic project details sections

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -594,7 +594,7 @@ button:hover {
 
 /* === PROJECT STUFF === */
 
-.project-details {
+.details {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -607,14 +607,14 @@ button:hover {
     padding: var(--spacing-2XL) var(--container-spacing-medium);
 }
 
-.project-details-list {
+.details-list {
     display: flex;
     flex-direction: column;
 
     gap: var(--spacing-M);
 }
 
-.project-details-list-items {
+.details-list-items {
     display: flex;
     flex-direction: column;
 

--- a/js/layout.js
+++ b/js/layout.js
@@ -26,8 +26,7 @@ export function createTwoColumnSection(leftKey, rightElements, translations, cur
   return wrapper;
 }
 
-export function createDesignProcessSection(translations, currentLang) {
-  const phases = [
+const defaultPhases = [
     {
       title: 'designprocess_title1',
       methods: [
@@ -68,19 +67,47 @@ export function createDesignProcessSection(translations, currentLang) {
     }
   ];
 
+export function createDesignProcessSection(translations, currentLang, phases = defaultPhases) {
+
   const wrapper = document.createElement('div');
-  wrapper.className = 'project-details';
+  wrapper.className = 'details';
 
   phases.forEach(phase => {
     const list = document.createElement('div');
-    list.className = 'project-details-list';
+    list.className = 'details-list';
 
     const h4 = document.createElement('h4');
     h4.textContent = translations[phase.title]?.[currentLang] || phase.title;
 
     const items = document.createElement('div');
-    items.className = 'project-details-list-items';
+    items.className = 'details-list-items';
     phase.methods.forEach(key => {
+      const span = document.createElement('span');
+      span.textContent = translations[key]?.[currentLang] || key;
+      items.appendChild(span);
+    });
+
+    list.append(h4, items);
+    wrapper.appendChild(list);
+  });
+
+  return wrapper;
+}
+
+export function createDetailsSection(sections, translations, currentLang) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'details';
+
+  sections.forEach(sec => {
+    const list = document.createElement('div');
+    list.className = 'details-list';
+
+    const h4 = document.createElement('h4');
+    h4.textContent = translations[sec.title]?.[currentLang] || sec.title;
+
+    const items = document.createElement('div');
+    items.className = 'details-list-items';
+    sec.items.forEach(key => {
       const span = document.createElement('span');
       span.textContent = translations[key]?.[currentLang] || key;
       items.appendChild(span);

--- a/js/project1.js
+++ b/js/project1.js
@@ -2,7 +2,11 @@ import { setLanguage, currentLang, translations, initLangToggle } from "./i18n.j
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
-import { createTwoColumnSection, createDesignProcessSection } from "./layout.js";
+import {
+  createTwoColumnSection,
+  createDesignProcessSection,
+  createDetailsSection,
+} from "./layout.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
@@ -21,7 +25,15 @@ function renderSections() {
 
   container.querySelectorAll(".dynamic-section").forEach((el) => el.remove());
 
+  const details = [
+    { title: "project_detail1", items: ["project_role1"] },
+    { title: "project_detail2", items: ["software_1"] },
+    { title: "project_detail3", items: ["project_team1", "project_team3", "project_team4"] },
+    { title: "project_detail4", items: ["project1_year"] }
+  ];
+
   const sections = [
+    { type: "details", data: details },
     { type: "twoColumn", left: "project1_sec1_title", text: "project1_sec1_text" },
     { type: "video", src: "./assets/videos/TimSchedlbauer_Portfoliovideo_Scene1.webm" },
     { type: "twoColumn", left: "project1_sec2_title", text: "project1_sec2_text" },
@@ -41,7 +53,9 @@ function renderSections() {
       el = document.createElement("div");
       el.appendChild(vid);
     } else if (sec.type === "designprocess") {
-      el = createDesignProcessSection(translations, currentLang);
+      el = createDesignProcessSection(translations, currentLang, sec.phases);
+    } else if (sec.type === "details") {
+      el = createDetailsSection(sec.data, translations, currentLang);
     }
     if (el) {
       el.classList.add("dynamic-section");

--- a/js/project2.js
+++ b/js/project2.js
@@ -1,14 +1,49 @@
-import { setLanguage, initLangToggle, currentLang } from "./i18n.js";
+import { setLanguage, initLangToggle, currentLang, translations } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
+import { createDetailsSection } from "./layout.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  initLangToggle();
+  initLangToggle(renderSections);
 
   initNav();
+  renderSections();
   initFadeAnimations();
 });
+
+function renderSections() {
+  const container = document.querySelector(".content-wrapper");
+  if (!container) return;
+
+  container.innerHTML = "";
+
+  const details = [
+    {
+      title: "project_detail1",
+      items: [
+        "project_role1",
+        "project_role2",
+        "project_role3",
+        "project_role4",
+        "project_role5",
+      ],
+    },
+    {
+      title: "project_detail2",
+      items: ["software_1", "software_6", "software_7", "software_10", "software_11"],
+    },
+    {
+      title: "project_detail3",
+      items: ["project_team1", "project_team2", "project_team3", "project_team4"],
+    },
+    { title: "project_detail4", items: ["project2_year"] },
+  ];
+
+  const el = createDetailsSection(details, translations, currentLang);
+  el.classList.add("dynamic-section");
+  container.appendChild(el);
+}

--- a/js/project3.js
+++ b/js/project3.js
@@ -1,14 +1,43 @@
-import { setLanguage, initLangToggle, currentLang } from "./i18n.js";
+import { setLanguage, initLangToggle, currentLang, translations } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
+import { createDetailsSection } from "./layout.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  initLangToggle();
+  initLangToggle(renderSections);
 
   initNav();
+  renderSections();
   initFadeAnimations();
 });
+
+function renderSections() {
+  const container = document.querySelector(".content-wrapper");
+  if (!container) return;
+
+  container.innerHTML = "";
+
+  const details = [
+    {
+      title: "project_detail1",
+      items: ["project_role1", "project_role3", "project_role4", "project_role5"],
+    },
+    {
+      title: "project_detail2",
+      items: ["software_2", "software_6", "software_7", "software_10", "software_11"],
+    },
+    {
+      title: "project_detail3",
+      items: ["project_team1", "project_team2", "project_team3", "project_team4"],
+    },
+    { title: "project_detail4", items: ["project3_year"] },
+  ];
+
+  const el = createDetailsSection(details, translations, currentLang);
+  el.classList.add("dynamic-section");
+  container.appendChild(el);
+}

--- a/project1.html
+++ b/project1.html
@@ -27,36 +27,7 @@
           </div>
         </div>
       </section>
-      <div class="content-wrapper">
-        <div class="project-details">
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail1"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="project_role1"></span>
-            </div>
-          </div>
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail2"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="software_1"></span>
-            </div>
-          </div>
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail3"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="project_team1"></span>
-              <span data-i18n="project_team3"></span>
-              <span data-i18n="project_team4"></span>
-            </div>
-          </div>
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail4"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="project1_year"></span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <div class="content-wrapper"></div>
     </main>
     <script type="module" src="js/project1.js"></script>
   </body>

--- a/project2.html
+++ b/project2.html
@@ -27,45 +27,7 @@
           </div>
         </div>
       </section>
-      <div class="content-wrapper">
-        <div class="project-details">
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail1"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="project_role1"></span>
-              <span data-i18n="project_role2"></span>
-              <span data-i18n="project_role3"></span>
-              <span data-i18n="project_role4"></span>
-              <span data-i18n="project_role5"></span>
-            </div>
-          </div>
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail2"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="software_1"></span>
-              <span data-i18n="software_6"></span>
-              <span data-i18n="software_7"></span>
-              <span data-i18n="software_10"></span>
-              <span data-i18n="software_11"></span>
-            </div>
-          </div>
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail3"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="project_team1"></span>
-              <span data-i18n="project_team2"></span>
-              <span data-i18n="project_team3"></span>
-              <span data-i18n="project_team4"></span>
-            </div>
-          </div>
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail4"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="project2_year"></span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <div class="content-wrapper"></div>
     </main>
     <script type="module" src="js/project2.js"></script>
   </body>

--- a/project3.html
+++ b/project3.html
@@ -27,44 +27,7 @@
           </div>
         </div>
       </section>
-      <div class="content-wrapper">
-        <div class="project-details">
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail1"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="project_role1"></span>
-              <span data-i18n="project_role3"></span>
-              <span data-i18n="project_role4"></span>
-              <span data-i18n="project_role5"></span>
-            </div>
-          </div>
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail2"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="software_2"></span>
-              <span data-i18n="software_6"></span>
-              <span data-i18n="software_7"></span>
-              <span data-i18n="software_10"></span>
-              <span data-i18n="software_11"></span>
-            </div>
-          </div>
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail3"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="project_team1"></span>
-              <span data-i18n="project_team2"></span>
-              <span data-i18n="project_team3"></span>
-              <span data-i18n="project_team4"></span>
-            </div>
-          </div>
-          <div class="project-details-list">
-            <h4 data-i18n="project_detail4"></h4>
-            <div class="project-details-list-items">
-              <span data-i18n="project3_year"></span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <div class="content-wrapper"></div>
     </main>
     <script type="module" src="js/project3.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- rename project-details classes to `details` and update styles
- add dynamic `createDetailsSection` builder
- refactor design process builder to use the same class names
- render details dynamically in project1–3 pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e5e0f56f88332891841389103efa4