### PR TITLE
Fix design process display and translation lookup

### DIFF
--- a/js/about.js
+++ b/js/about.js
@@ -1,4 +1,10 @@
-import { setLanguage, currentLang, translations, initLangToggle } from "./i18n.js";
+import {
+  setLanguage,
+  currentLang,
+  translations,
+  initLangToggle,
+  getTranslation,
+} from "./i18n.js";
 import { initNav } from "./nav.js";
 import { createTwoColumnSection } from "./layout.js";
 import { initFadeAnimations } from "./animations.js";
@@ -31,26 +37,24 @@ async function loadExperience() {
 
       const title = document.createElement("h5");
       title.className = "job-title";
-      title.textContent = translations[job.title]?.[currentLang] || job.title;
+      title.textContent = getTranslation(job.title, currentLang);
 
       const metaWrapper = document.createElement("div");
       metaWrapper.className = "job-meta";
 
       const company = document.createElement("div");
       company.className = "job-company";
-      company.textContent =
-        translations[job.company]?.[currentLang] || job.company;
+      company.textContent = getTranslation(job.company, currentLang);
 
       const period = document.createElement("div");
       period.className = "job-period";
-      period.textContent =
-        translations[job.period]?.[currentLang] || job.period;
+      period.textContent = getTranslation(job.period, currentLang);
 
       metaWrapper.append(company, period);
 
       const text = document.createElement("div");
       text.className = "job-text";
-      text.textContent = translations[job.text]?.[currentLang] || job.text;
+      text.textContent = getTranslation(job.text, currentLang);
 
       wrapper.append(title, metaWrapper, text);
       return wrapper;

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,6 +1,13 @@
 export let currentLang = "de";
 export let translations = {};
 
+export function getTranslation(key, lang = currentLang) {
+  const value = translations[key];
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && value[lang]) return value[lang];
+  return key;
+}
+
 async function loadTranslations() {
   const response = await fetch("lang/lang.json");
   translations = await response.json();
@@ -19,16 +26,9 @@ export async function setLanguage(lang) {
 
   document.querySelectorAll("[data-i18n]").forEach((el) => {
     const key = el.getAttribute("data-i18n");
-    const value = translations[key];
     const isHTML = el.hasAttribute("data-i18n-html");
 
-    let content = "";
-
-    if (typeof value === "string") {
-      content = value;
-    } else if (value && typeof value === "object" && value[lang]) {
-      content = value[lang];
-    }
+    const content = getTranslation(key, lang);
 
     if (isHTML) {
       el.innerHTML = content;

--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,10 @@
-import { setLanguage, currentLang, translations, initLangToggle } from "./i18n.js";
+import {
+  setLanguage,
+  currentLang,
+  translations,
+  initLangToggle,
+  getTranslation,
+} from "./i18n.js";
 import { initNav, highlightProjectButtons } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
@@ -42,22 +48,8 @@ function renderChipsFromI18n({ prefix, containerId }) {
   keys.forEach((key, index) => {
     const value = translations[key];
 
-    let label = "";
-    let level = 0;
-
-    if (typeof value === "string") {
-      label = value;
-    } else if (typeof value === "object") {
-      if (value.label) {
-        label =
-          typeof value.label === "object"
-            ? value.label[currentLang]
-            : value.label;
-      } else if (value[currentLang]) {
-        label = value[currentLang];
-      }
-      level = value.level ?? 0;
-    }
+    const label = getTranslation(key, currentLang);
+    const level = typeof value === "object" && value.level ? value.level : 0;
 
     const chip = document.createElement("div");
     chip.className = "chip";
@@ -114,8 +106,8 @@ async function renderProjects() {
     ];
 
     projects.forEach((proj, index) => {
-      const title = translations[proj.titleKey]?.[currentLang] || "";
-      const desc = translations[proj.descKey]?.[currentLang] || "";
+      const title = getTranslation(proj.titleKey, currentLang);
+      const desc = getTranslation(proj.descKey, currentLang);
 
       const card = document.createElement("a");
       card.className = "project-card";

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,3 +1,5 @@
+import { getTranslation } from "./i18n.js";
+
 export function createTwoColumnSection(
   leftKey,
   rightElements,
@@ -13,7 +15,7 @@ export function createTwoColumnSection(
 
   const headline = document.createElement("h4");
   headline.className = "fade-left";
-  headline.textContent = translations[leftKey]?.[currentLang] || leftKey;
+  headline.textContent = getTranslation(leftKey, currentLang);
   leftCol.appendChild(headline);
 
   const rightCol = document.createElement("div");
@@ -45,13 +47,13 @@ export function createDesignProcessSection(
     list.className = "details-list";
 
     const h4 = document.createElement("h4");
-    h4.textContent = translations[phase.title]?.[currentLang] || phase.title;
+    h4.textContent = getTranslation(phase.title, currentLang);
 
     const items = document.createElement("div");
     items.className = "details-list-items";
     phase.methods.forEach((key) => {
       const span = document.createElement("span");
-      span.textContent = translations[key]?.[currentLang] || key;
+      span.textContent = getTranslation(key, currentLang);
       items.appendChild(span);
     });
 
@@ -71,13 +73,13 @@ export function createDetailsSection(sections, translations, currentLang) {
     list.className = "details-list";
 
     const h4 = document.createElement("h4");
-    h4.textContent = translations[sec.title]?.[currentLang] || sec.title;
+    h4.textContent = getTranslation(sec.title, currentLang);
 
     const items = document.createElement("div");
     items.className = "details-list-items";
     sec.items.forEach((key) => {
       const span = document.createElement("span");
-      span.textContent = translations[key]?.[currentLang] || key;
+      span.textContent = getTranslation(key, currentLang);
       items.appendChild(span);
     });
 

--- a/js/project1.js
+++ b/js/project1.js
@@ -3,6 +3,7 @@ import {
   currentLang,
   translations,
   initLangToggle,
+  getTranslation,
 } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
@@ -104,7 +105,7 @@ function renderSections() {
     let el;
     if (sec.type === "twoColumn") {
       const p = document.createElement("p");
-      p.textContent = translations[sec.text]?.[currentLang] || sec.text;
+      p.textContent = getTranslation(sec.text, currentLang);
       el = createTwoColumnSection(sec.left, [p], translations, currentLang);
     } else if (sec.type === "video") {
       const vid = document.createElement("video");
@@ -112,8 +113,8 @@ function renderSections() {
       vid.controls = true;
       el = document.createElement("div");
       el.appendChild(vid);
-    } else if (sec.type === "designprocess") {
-      el = createDesignProcessSection(translations, currentLang, sec.phases);
+    } else if (sec.type === "designPhases") {
+      el = createDesignProcessSection(sec.data, translations, currentLang);
     } else if (sec.type === "details") {
       el = createDetailsSection(sec.data, translations, currentLang);
     }


### PR DESCRIPTION
## Summary
- add `getTranslation` helper in `i18n.js`
- use `getTranslation` in layout helpers and page scripts
- fix design phase rendering in project1 page

## Testing
- `node --check js/i18n.js`
- `node --check js/layout.js`
- `node --check js/about.js`
- `node --check js/index.js`
- `node --check js/project1.js`


------
https://chatgpt.com/codex/tasks/task_e_687e64d770608332af72693fa2cea2f9