### PR TITLE
Improve i18n support and caching

### DIFF
--- a/header.html
+++ b/header.html
@@ -1,10 +1,10 @@
 <header class="fade-top">
   <nav>
     <a class="nav-brand" href="index.html">
-      <div class="logo"><img src="./assets/images/logo/Logo.svg" /></div>
+      <div class="logo"><img src="./assets/images/logo/Logo.svg" alt="Tim Schedlbauer Logo" /></div>
       <div class="link">Tim <br />Schedlbauer</div>
     </a>
-    <button class="burger" id="burger-toggle" aria-label="Menü öffnen">&#9776;</button>
+    <button class="burger" id="burger-toggle" data-i18n="menu_toggle" data-i18n-attr="aria-label">&#9776;</button>
     <div class="nav-menu" id="nav-menu">
       <a class="nav-link js-to-projects" href="index.html#projects" data-i18n="projects"></a>
       <a class="nav-link" href="about.html" data-i18n="about"></a>

--- a/js/about.js
+++ b/js/about.js
@@ -14,9 +14,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  initLangToggle(async () => {
-    await loadExperience(); // Erfahrungseinträge neu übersetzen
-  });
+  initLangToggle();
 
   initNav();
   await loadExperience();
@@ -37,6 +35,7 @@ async function loadExperience() {
 
       const title = document.createElement("h5");
       title.className = "job-title";
+      title.setAttribute("data-i18n", job.title);
       title.textContent = getTranslation(job.title, currentLang);
 
       const metaWrapper = document.createElement("div");
@@ -44,16 +43,19 @@ async function loadExperience() {
 
       const company = document.createElement("div");
       company.className = "job-company";
+      company.setAttribute("data-i18n", job.company);
       company.textContent = getTranslation(job.company, currentLang);
 
       const period = document.createElement("div");
       period.className = "job-period";
+      period.setAttribute("data-i18n", job.period);
       period.textContent = getTranslation(job.period, currentLang);
 
       metaWrapper.append(company, period);
 
       const text = document.createElement("div");
       text.className = "job-text";
+      text.setAttribute("data-i18n", job.text);
       text.textContent = getTranslation(job.text, currentLang);
 
       wrapper.append(title, metaWrapper, text);

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,5 +1,6 @@
 export let currentLang = "de";
 export let translations = {};
+let translationsPromise;
 
 export function getTranslation(key, lang = currentLang) {
   const value = translations[key];
@@ -16,8 +17,14 @@ export function getTranslation(key, lang = currentLang) {
 }
 
 async function loadTranslations() {
-  const response = await fetch("lang/lang.json");
-  translations = await response.json();
+  if (translationsPromise) return translationsPromise;
+  translationsPromise = fetch("lang/lang.json")
+    .then((response) => response.json())
+    .then((json) => {
+      translations = json;
+      return translations;
+    });
+  return translationsPromise;
 }
 
 function updateLangButtonUI() {
@@ -34,8 +41,14 @@ export async function setLanguage(lang) {
   document.querySelectorAll("[data-i18n]").forEach((el) => {
     const key = el.getAttribute("data-i18n");
     const isHTML = el.hasAttribute("data-i18n-html");
+    const attr = el.getAttribute("data-i18n-attr");
 
     const content = getTranslation(key, lang);
+
+    if (attr) {
+      el.setAttribute(attr, content);
+      if (!isHTML) return; // skip content update if only attribute is translated
+    }
 
     if (isHTML) {
       el.innerHTML = content;

--- a/js/index.js
+++ b/js/index.js
@@ -13,10 +13,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader({ transparent: true, indexPage: true });
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  initLangToggle(async () => {
-    await renderChipsAndProjects();
-    initFadeAnimations();
-  });
+  initLangToggle();
 
   initNav(highlightProjectButtons);
   await renderChipsAndProjects();
@@ -56,6 +53,7 @@ function renderChipsFromI18n({ prefix, containerId }) {
     chip.style.setProperty("--fill", "0%");
 
     const span = document.createElement("span");
+    span.setAttribute("data-i18n", key);
     span.textContent = label;
     chip.appendChild(span);
     container.appendChild(chip);
@@ -133,11 +131,21 @@ async function renderProjects() {
 
       const info = document.createElement("div");
       info.className = "project-info";
-      info.innerHTML = `
-        <div class="project-tags">${tagsHTML}</div>
-        <h3>${title}</h3>
-        <p class="text-block">${desc}</p>
-      `;
+
+      const tagsEl = document.createElement("div");
+      tagsEl.className = "project-tags";
+      tagsEl.innerHTML = tagsHTML;
+
+      const h3 = document.createElement("h3");
+      h3.setAttribute("data-i18n", proj.titleKey);
+      h3.textContent = title;
+
+      const p = document.createElement("p");
+      p.className = "text-block";
+      p.setAttribute("data-i18n", proj.descKey);
+      p.textContent = desc;
+
+      info.append(tagsEl, h3, p);
 
       card.appendChild(imageWrapper);
       card.appendChild(info);

--- a/js/layout.js
+++ b/js/layout.js
@@ -15,6 +15,7 @@ export function createTwoColumnSection(
 
   const headline = document.createElement("h4");
   headline.className = "fade-left";
+  headline.setAttribute("data-i18n", leftKey);
   headline.textContent = getTranslation(leftKey, currentLang);
   leftCol.appendChild(headline);
 
@@ -60,12 +61,14 @@ export function createDesignProcessSection(
     }
 
     const h4 = document.createElement("h4");
+    h4.setAttribute("data-i18n", phase.title);
     h4.textContent = getTranslation(phase.title, currentLang);
 
     const items = document.createElement("div");
     items.className = "process-list-items";
     phase.methods.forEach((key) => {
       const span = document.createElement("span");
+      span.setAttribute("data-i18n", key);
       span.textContent = getTranslation(key, currentLang);
       items.appendChild(span);
     });
@@ -86,13 +89,21 @@ export function createDetailsSection(sections, translations, currentLang) {
     list.className = "details-list";
 
     const h4 = document.createElement("h4");
+    h4.setAttribute("data-i18n", sec.title);
     h4.textContent = getTranslation(sec.title, currentLang);
 
     const items = document.createElement("div");
     items.className = "details-list-items";
     sec.items.forEach((key) => {
       const span = document.createElement("span");
-      span.innerHTML = getTranslation(key, currentLang);
+      span.setAttribute("data-i18n", key);
+      const content = getTranslation(key, currentLang);
+      if (content.includes("<br>") || content.includes("\n")) {
+        span.setAttribute("data-i18n-html", "");
+        span.innerHTML = content;
+      } else {
+        span.textContent = content;
+      }
       items.appendChild(span);
     });
 
@@ -108,6 +119,7 @@ export function createProcessStep(step, translations, currentLang) {
   wrapper.className = "process-step";
 
   const h1 = document.createElement("h1");
+  h1.setAttribute("data-i18n", step.title);
   h1.textContent = getTranslation(step.title, currentLang);
 
   wrapper.appendChild(h1);

--- a/js/project1.js
+++ b/js/project1.js
@@ -114,6 +114,8 @@ function renderSections() {
       text: "competitiveanalysis_project1",
     },
     { type: "group-end" },
+    { type: "step", h1: "designprocess_title2" },
+    { type: "group-start" },
     {
       type: "twoColumn",
       left: "flowgraph",
@@ -132,6 +134,9 @@ function renderSections() {
       type: "image",
       src: "assets/images/project-fischer/FischerProfil_Prototypen.webp",
     },
+    { type: "group-end" },
+    { type: "step", h1: "designprocess_title3" },
+    { type: "group-start" },
     {
       type: "twoColumn",
       left: "designsystem",
@@ -154,6 +159,9 @@ function renderSections() {
       type: "image",
       src: "assets/images/project-fischer/FischerProfil_UI.webp",
     },
+    { type: "group-end" },
+    { type: "step", h1: "designprocess_title5" },
+    { type: "group-start" },
     {
       type: "twoColumn",
       left: "moredrafts",
@@ -164,6 +172,7 @@ function renderSections() {
       left: "researchtesting",
       text: "researchtesting_project1",
     },
+    { type: "group-end" },
   ];
 
   let groupWrapper = null; // für <div class="content-wrapper">

--- a/js/project1.js
+++ b/js/project1.js
@@ -14,13 +14,13 @@ import {
   createDetailsSection,
   createProcessStep,
 } from "./layout.js";
-import { convertYouTubeUrl, parseYouTubeStartTime } from "./youtubeUtils.js";
+import { convertYouTubeUrl } from "./youtubeUtils.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  initLangToggle(renderSections);
+  initLangToggle();
 
   initNav();
   renderSections();
@@ -185,7 +185,14 @@ function renderSections() {
     let el;
     if (sec.type === "twoColumn") {
       const p = document.createElement("p");
-      p.textContent = getTranslation(sec.text, currentLang);
+      p.setAttribute("data-i18n", sec.text);
+      const content = getTranslation(sec.text, currentLang);
+      if (content.includes("<br>") || content.includes("\n")) {
+        p.setAttribute("data-i18n-html", "");
+        p.innerHTML = content;
+      } else {
+        p.textContent = content;
+      }
       el = createTwoColumnSection(sec.left, [p], translations, currentLang);
     } else if (sec.type === "youtube-video") {
       const iframe = document.createElement("iframe");

--- a/js/project2.js
+++ b/js/project2.js
@@ -8,13 +8,13 @@ import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
 import { createDetailsSection } from "./layout.js";
-import { convertYouTubeUrl, parseYouTubeStartTime } from "./youtubeUtils.js";
+import { convertYouTubeUrl } from "./youtubeUtils.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  initLangToggle(renderSections);
+  initLangToggle();
 
   initNav();
   renderSections();

--- a/js/project3.js
+++ b/js/project3.js
@@ -8,13 +8,13 @@ import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
 import { createDetailsSection } from "./layout.js";
-import { convertYouTubeUrl, parseYouTubeStartTime } from "./youtubeUtils.js";
+import { convertYouTubeUrl } from "./youtubeUtils.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
   await setLanguage(localStorage.getItem("lang") || "de");
 
-  initLangToggle(renderSections);
+  initLangToggle();
 
   initNav();
   renderSections();

--- a/lang/lang.json
+++ b/lang/lang.json
@@ -2,6 +2,7 @@
   "projects": { "de": "Projekte", "en": "Projects" },
   "about": { "de": "Über mich", "en": "About" },
   "contact": { "de": "Kontakt", "en": "Contact" },
+  "menu_toggle": { "de": "Menü öffnen", "en": "Open menu" },
   "name": "Tim Schedlbauer",
   "hero1_title": "UI/UX Designer",
   "hero1_subtitle": {

--- a/lang/lang.json
+++ b/lang/lang.json
@@ -323,6 +323,10 @@
     "de": "Testing",
     "en": "Testing"
   },
+  "designprocess_title5": {
+    "de": "Fazit",
+    "en": "Conclusion"
+  },
   "designprocess_analyse_method1": {
     "de": "Experten Evaluation",
     "en": "Expert evaluation"


### PR DESCRIPTION
## Summary
- avoid rerendering sections on language change
- cache translations and add attribute translation support
- mark dynamic elements with `data-i18n` and `data-i18n-html`
- localize burger-menu label and add logo alt text
- remove unused imports

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fad2edec883329d90faa17ea84ff3