### PR TITLE
Implement several improvements from review

### DIFF
--- a/about.html
+++ b/about.html
@@ -21,7 +21,7 @@
       <section class="smooth-wrapper" id="luxy">
         <div class="about-hero">
           <div class="about-hero-image fade-left">
-            <img src="./assets/images/profile/ProfileImage.jpg" />
+            <img src="./assets/images/profile/ProfileImage.jpg" alt="Profile" />
           </div>
           <div
             class="about-hero-text fade-right"

--- a/archive.html
+++ b/archive.html
@@ -27,7 +27,7 @@
                 <h3 data-i18n="project5_title"></h3>
               </div>
               <div class="archive-card-image-wrapper">
-                <img src="assets/images/project-archive/Vishow.webp" />
+                <img src="assets/images/project-archive/Vishow.webp" alt="VISPA" />
               </div>
               <div class="archive-card-text-wrapper">
                 <div class="" data-i18n="project5_desc"></div>

--- a/js/about.js
+++ b/js/about.js
@@ -1,7 +1,6 @@
 import {
   setLanguage,
   currentLang,
-  translations,
   initLangToggle,
   getTranslation,
 } from "./i18n.js";
@@ -67,13 +66,12 @@ async function loadExperience() {
       createTwoColumnSection(
         "about-experience-headline",
         entries,
-        translations,
-        currentLang,
         "experience-list"
       )
     );
     initFadeAnimations();
   } catch (err) {
     console.error("Fehler beim Laden der Erfahrung:", err);
+    container.innerHTML = `<p>${getTranslation("load_error", currentLang)}</p>`;
   }
 }

--- a/js/animations.js
+++ b/js/animations.js
@@ -8,8 +8,7 @@ export function initFadeAnimations() {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           entry.target.classList.add('in-view');
-        } else {
-          entry.target.classList.remove('in-view');
+          observer.unobserve(entry.target);
         }
       });
     },

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,12 +1,6 @@
 import { currentLang, getTranslation } from "./i18n.js";
 
-export function createTwoColumnSection(
-  leftKey,
-  rightElements,
-  translations,
-  currentLang,
-  rightId
-) {
+export function createTwoColumnSection(leftKey, rightElements, rightId) {
   const wrapper = document.createElement("div");
   wrapper.className = "two-column-list";
 
@@ -39,11 +33,7 @@ export function createTwoColumnSection(
   return wrapper;
 }
 
-export function createDesignProcessSection(
-  designPhases,
-  translations,
-  currentLang
-) {
+export function createDesignProcessSection(designPhases) {
   const wrapper = document.createElement("div");
   wrapper.className = "process";
 
@@ -91,7 +81,7 @@ export function createDesignProcessSection(
   return wrapper;
 }
 
-export function createDetailsSection(sections, translations, currentLang) {
+export function createDetailsSection(sections) {
   const wrapper = document.createElement("div");
   wrapper.className = "details";
 
@@ -125,7 +115,7 @@ export function createDetailsSection(sections, translations, currentLang) {
   return wrapper;
 }
 
-export function createProcessStep(step, translations, currentLang) {
+export function createProcessStep(step) {
   const wrapper = document.createElement("div");
   wrapper.className = "process-step";
 
@@ -138,7 +128,7 @@ export function createProcessStep(step, translations, currentLang) {
   return wrapper;
 }
 
-export function createProjectHeroSection(config, translations, currentLang) {
+export function createProjectHeroSection(config) {
   const { className, titleKey, textKey, imageSrc, imageAlt } = config;
 
   const section = document.createElement("section");
@@ -177,7 +167,7 @@ export function createProjectHeroSection(config, translations, currentLang) {
   return section;
 }
 
-export function createMoreProjectsSection(url, translations, currentLang) {
+export function createMoreProjectsSection(url) {
   const section = document.createElement("section");
   section.classList.add("more-project-links");
 

--- a/js/project1.js
+++ b/js/project1.js
@@ -1,7 +1,6 @@
 import {
   setLanguage,
   currentLang,
-  translations,
   initLangToggle,
   getTranslation,
 } from "./i18n.js";
@@ -34,17 +33,13 @@ function renderSections() {
 
   container.querySelectorAll(".dynamic-section").forEach((el) => el.remove());
 
-  const hero = createProjectHeroSection(
-    {
-      className: "project1",
-      titleKey: "project1_title",
-      textKey: "project1_text",
-      imageSrc: "assets/images/project-cards/FischerShowroom-Image.webp",
-      imageAlt: "Fischer Profil Showroom",
-    },
-    translations,
-    currentLang
-  );
+  const hero = createProjectHeroSection({
+    className: "project1",
+    titleKey: "project1_title",
+    textKey: "project1_text",
+    imageSrc: "assets/images/project-cards/FischerShowroom-Image.webp",
+    imageAlt: "Fischer Profil Showroom",
+  });
 
   hero.classList.add("dynamic-section");
   container.prepend(hero);
@@ -243,7 +238,7 @@ function renderSections() {
       } else {
         p.textContent = content;
       }
-      el = createTwoColumnSection(sec.left, [p], translations, currentLang);
+        el = createTwoColumnSection(sec.left, [p]);
     } else if (sec.type === "youtube-video") {
       const iframe = document.createElement("iframe");
       iframe.src = convertYouTubeUrl(sec.src);
@@ -257,11 +252,11 @@ function renderSections() {
       el.classList.add("youtube-wrapper");
       el.appendChild(iframe);
     } else if (sec.type === "designPhases") {
-      el = createDesignProcessSection(sec.data, translations, currentLang);
+      el = createDesignProcessSection(sec.data);
     } else if (sec.type === "step") {
-      el = createProcessStep({ title: sec.h1 }, translations, currentLang);
+      el = createProcessStep({ title: sec.h1 });
     } else if (sec.type === "details") {
-      el = createDetailsSection(sec.data, translations, currentLang);
+      el = createDetailsSection(sec.data);
     } else if (sec.type === "image") {
       const img = document.createElement("img");
       img.src = sec.src;
@@ -269,7 +264,7 @@ function renderSections() {
       el = document.createElement("div");
       el.appendChild(img);
     } else if (sec.type === "moreProjects") {
-      el = createMoreProjectsSection(sec.data, translations, currentLang);
+      el = createMoreProjectsSection(sec.data);
     }
 
     if (el) {

--- a/js/project2.js
+++ b/js/project2.js
@@ -1,7 +1,6 @@
 import {
   setLanguage,
   currentLang,
-  translations,
   initLangToggle,
   getTranslation,
 } from "./i18n.js";
@@ -34,17 +33,13 @@ function renderSections() {
 
   container.querySelectorAll(".dynamic-section").forEach((el) => el.remove());
 
-  const hero = createProjectHeroSection(
-    {
-      className: "project2",
-      titleKey: "project2_title",
-      textKey: "project2_text",
-      imageSrc: "assets/images/project-cards/VispaGame-Image.webp",
-      imageAlt: "VISPA Fun",
-    },
-    translations,
-    currentLang
-  );
+  const hero = createProjectHeroSection({
+    className: "project2",
+    titleKey: "project2_title",
+    textKey: "project2_text",
+    imageSrc: "assets/images/project-cards/VispaGame-Image.webp",
+    imageAlt: "VISPA Fun",
+  });
 
   hero.classList.add("dynamic-section");
   container.prepend(hero);
@@ -448,12 +443,7 @@ function renderSections() {
         contentNodes = [processKey(sec.text)];
       }
 
-      el = createTwoColumnSection(
-        sec.left,
-        contentNodes,
-        translations,
-        currentLang
-      );
+        el = createTwoColumnSection(sec.left, contentNodes);
     } else if (sec.type === "youtube-video") {
       const iframe = document.createElement("iframe");
       iframe.src = convertYouTubeUrl(sec.src);
@@ -467,11 +457,11 @@ function renderSections() {
       el.classList.add("youtube-wrapper");
       el.appendChild(iframe);
     } else if (sec.type === "designPhases") {
-      el = createDesignProcessSection(sec.data, translations, currentLang);
+      el = createDesignProcessSection(sec.data);
     } else if (sec.type === "step") {
-      el = createProcessStep({ title: sec.h1 }, translations, currentLang);
+      el = createProcessStep({ title: sec.h1 });
     } else if (sec.type === "details") {
-      el = createDetailsSection(sec.data, translations, currentLang);
+      el = createDetailsSection(sec.data);
     } else if (sec.type === "image") {
       const img = document.createElement("img");
       img.src = sec.src;
@@ -479,7 +469,7 @@ function renderSections() {
       el = document.createElement("div");
       el.appendChild(img);
     } else if (sec.type === "moreProjects") {
-      el = createMoreProjectsSection(sec.data, translations, currentLang);
+      el = createMoreProjectsSection(sec.data);
     }
 
     if (el) {

--- a/js/project3.js
+++ b/js/project3.js
@@ -1,7 +1,6 @@
 import {
   setLanguage,
   currentLang,
-  translations,
   initLangToggle,
   getTranslation,
 } from "./i18n.js";
@@ -34,17 +33,13 @@ function renderSections() {
 
   container.querySelectorAll(".dynamic-section").forEach((el) => el.remove());
 
-  const hero = createProjectHeroSection(
-    {
-      className: "project3",
-      titleKey: "project3_title",
-      textKey: "project3_text",
-      imageSrc: "assets/images/project-cards/VispaWorkshop-Image.webp",
-      imageAlt: "VISPA Workshops",
-    },
-    translations,
-    currentLang
-  );
+  const hero = createProjectHeroSection({
+    className: "project3",
+    titleKey: "project3_title",
+    textKey: "project3_text",
+    imageSrc: "assets/images/project-cards/VispaWorkshop-Image.webp",
+    imageAlt: "VISPA Workshops",
+  });
 
   hero.classList.add("dynamic-section");
   container.prepend(hero);
@@ -425,12 +420,7 @@ function renderSections() {
         contentNodes = [processKey(sec.text)];
       }
 
-      el = createTwoColumnSection(
-        sec.left,
-        contentNodes,
-        translations,
-        currentLang
-      );
+        el = createTwoColumnSection(sec.left, contentNodes);
     } else if (sec.type === "youtube-video") {
       const iframe = document.createElement("iframe");
       iframe.src = convertYouTubeUrl(sec.src);
@@ -444,11 +434,11 @@ function renderSections() {
       el.classList.add("youtube-wrapper");
       el.appendChild(iframe);
     } else if (sec.type === "designPhases") {
-      el = createDesignProcessSection(sec.data, translations, currentLang);
+      el = createDesignProcessSection(sec.data);
     } else if (sec.type === "step") {
-      el = createProcessStep({ title: sec.h1 }, translations, currentLang);
+      el = createProcessStep({ title: sec.h1 });
     } else if (sec.type === "details") {
-      el = createDetailsSection(sec.data, translations, currentLang);
+      el = createDetailsSection(sec.data);
     } else if (sec.type === "image") {
       const img = document.createElement("img");
       img.src = sec.src;
@@ -456,7 +446,7 @@ function renderSections() {
       el = document.createElement("div");
       el.appendChild(img);
     } else if (sec.type === "moreProjects") {
-      el = createMoreProjectsSection(sec.data, translations, currentLang);
+      el = createMoreProjectsSection(sec.data);
     }
 
     if (el) {

--- a/lang/lang.json
+++ b/lang/lang.json
@@ -864,5 +864,9 @@
   "ux2": "UX",
   "3d": "3D,",
   "3d-print": "3D-Print,",
-  "code": "Code"
+  "code": "Code",
+  "load_error": {
+    "de": "Fehler beim Laden der Daten.",
+    "en": "Error loading data."
+  }
 }


### PR DESCRIPTION
## Summary
- add missing alt attributes
- display error message when about data fails to load
- stop observing elements after fade animation triggers
- simplify layout helper API and usage
- add translation for generic load error

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Portfolio/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6882295595b88332944de35dee569d1f