### PR TITLE
Fix mobile section scroll behavior

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -921,14 +921,14 @@ img {
         align-items: stretch;
     }
 
-    .section-mobile-overflow {
+    .section-mobile-overflow .scroll-content {
         overflow-y: auto;
         box-sizing: border-box;
         scrollbar-width: none;
         -ms-overflow-style: none;
     }
 
-    .section-mobile-overflow::-webkit-scrollbar {
+    .section-mobile-overflow .scroll-content::-webkit-scrollbar {
         display: none;
     }
 

--- a/index.html
+++ b/index.html
@@ -61,9 +61,10 @@
           ></video>
         </div>
       </section>
-      <section class="section section-mobile-overflow">
-        <div class="max-width">
-          <div class="skills-wrapper">
+      <section class="section section-scrollable section-mobile-overflow">
+        <div class="scroll-content">
+          <div class="max-width">
+            <div class="skills-wrapper">
             <div class="hero-text no-max-width">
               <div class="hero-text-subhead" data-i18n="skills-subtitle"></div>
               <h1 data-i18n="skills-title"></h1>
@@ -79,6 +80,7 @@
               onclick="window.location.href='about.html'"
             ></button>
           </div>
+        </div>
         </div>
       </section>
       <section id="projects-section" class="section section-scrollable">

--- a/js/index.js
+++ b/js/index.js
@@ -172,6 +172,9 @@ function setupScrollAndNavigation() {
     isAnimating = true;
 
     const target = sections[index];
+    const fromIndex = currentIndex;
+    const direction = index > fromIndex ? 1 : -1;
+
     gsap.to(window, {
       scrollTo: { y: target.offsetTop },
       duration: 1,
@@ -179,7 +182,14 @@ function setupScrollAndNavigation() {
       onComplete: () => {
         currentIndex = index;
         const scrollContainer = getScrollContainer(target);
-        if (scrollContainer) scrollContainer.scrollTop = 0;
+        if (scrollContainer) {
+          if (direction < 0) {
+            scrollContainer.scrollTop =
+              scrollContainer.scrollHeight - scrollContainer.clientHeight;
+          } else {
+            scrollContainer.scrollTop = 0;
+          }
+        }
         isAnimating = false;
         highlightProjectButtons(target.id === "projects-section");
       },


### PR DESCRIPTION
## Summary
- make the skills/tools section use the scrollable layout
- ensure mobile overflow styling applies to the inner scroll container

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68824a20839883329e0fe0c6c6fbf28a