### PR TITLE
Add modular cookie consent banner

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,6 +15,7 @@
       href="https://fonts.googleapis.com/css?family=Comfortaa:200,400,500,700&display=swap"
       rel="stylesheet"
     />
+
   </head>
   <body>
     <main>
@@ -47,5 +48,6 @@
         });
       }
     </script>
+    <script src="js/cookie-consent.js"></script>
   </body>
 </html>

--- a/archive.html
+++ b/archive.html
@@ -10,8 +10,10 @@
       href="https://fonts.googleapis.com/css?family=Comfortaa:200,400,500,700&display=swap"
       rel="stylesheet"
     />
+
   </head>
   <body>
+
     <main>
       <div class="smooth-wrapper" id="luxy">
         <div class="content-wrapper">
@@ -155,5 +157,6 @@
       </div>
     </main>
     <script type="module" src="js/archive.js"></script>
+    <script src="js/cookie-consent.js"></script>
   </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1061,6 +1061,10 @@ body.scroll-snap .footer-section {
     text-align: center;
 }
 
+#cookie-banner .cookie-buttons {
+    margin-top: 0.5rem;
+}
+
 #cookie-banner button {
     margin-left: 1rem;
     padding: 0.5rem 1rem;

--- a/css/styles.css
+++ b/css/styles.css
@@ -941,6 +941,34 @@ body.scroll-snap .footer-section {
     font-size: var(--font-size-s);
 }
 
+/* === Cookie Banner === */
+#cookie-banner {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: var(--spacing-XS);
+    margin: 0 auto;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 1rem;
+    display: none;
+    z-index: 1000;
+    font-size: 14px;
+    text-align: center;
+    justify-content: center;
+    align-items: center;
+}
+
+#cookie-banner .cookie-buttons {}
+
+#cookie-banner button {
+    padding: var(--spacing-XS);
+    cursor: pointer;
+    background-color: unset;
+    font-size: 16px;
+    color: white;
+}
+
 
 
 /* === TABLET NAV === */
@@ -1045,28 +1073,4 @@ body.scroll-snap .footer-section {
     .footer-buttons {
         flex-direction: column;
     }
-}
-/* === Cookie Banner === */
-#cookie-banner {
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.8);
-    color: #fff;
-    padding: 1rem;
-    display: none;
-    z-index: 1000;
-    font-family: sans-serif;
-    text-align: center;
-}
-
-#cookie-banner .cookie-buttons {
-    margin-top: 0.5rem;
-}
-
-#cookie-banner button {
-    margin-left: 1rem;
-    padding: 0.5rem 1rem;
-    cursor: pointer;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1046,3 +1046,23 @@ body.scroll-snap .footer-section {
         flex-direction: column;
     }
 }
+/* === Cookie Banner === */
+#cookie-banner {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 1rem;
+    display: none;
+    z-index: 1000;
+    font-family: sans-serif;
+    text-align: center;
+}
+
+#cookie-banner button {
+    margin-left: 1rem;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+}

--- a/imprint.html
+++ b/imprint.html
@@ -15,8 +15,10 @@
       href="https://fonts.googleapis.com/css?family=Comfortaa:200,400,500,700&display=swap"
       rel="stylesheet"
     />
+
   </head>
   <body>
+
     <main>
       <div class="smooth-wrapper" id="luxy"></div>
     </main>
@@ -32,5 +34,6 @@
         });
       }
     </script>
+    <script src="js/cookie-consent.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -96,5 +96,6 @@
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.7/dist/ScrollToPlugin.min.js"></script>
 
     <script type="module" src="js/index.js"></script>
+    <script src="js/cookie-consent.js"></script>
   </body>
 </html>

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -10,24 +10,37 @@ function loadHotjar() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    if (localStorage.getItem('cookieConsent') === 'accepted') {
+    const consent = localStorage.getItem('cookieConsent');
+    if (consent === 'accepted') {
         loadHotjar();
+        return;
+    }
+    if (consent === 'declined') {
         return;
     }
 
     const banner = document.createElement('div');
     banner.id = 'cookie-banner';
     banner.innerHTML =
-        "Diese Website verwendet Cookies zur Analyse. Durch Klick auf 'Akzeptieren' stimmst du der Nutzung zu. " +
-        "<button id='accept-cookies'>Akzeptieren</button>";
+        "Diese Website verwendet Cookies zur Analyse. Durch Klick auf 'Akzeptieren' stimmst du der Nutzung zu." +
+        "<div class='cookie-buttons'>" +
+        "<button id='accept-cookies'>Akzeptieren</button>" +
+        "<button id='decline-cookies'>Ablehnen</button>" +
+        "</div>";
 
     document.body.appendChild(banner);
     banner.style.display = 'block';
 
-    const btn = banner.querySelector('#accept-cookies');
-    btn.addEventListener('click', () => {
+    const acceptBtn = banner.querySelector('#accept-cookies');
+    const declineBtn = banner.querySelector('#decline-cookies');
+    acceptBtn.addEventListener('click', () => {
         localStorage.setItem('cookieConsent', 'accepted');
         banner.remove();
         loadHotjar();
+    });
+
+    declineBtn.addEventListener('click', () => {
+        localStorage.setItem('cookieConsent', 'declined');
+        banner.remove();
     });
 });

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -1,0 +1,33 @@
+function loadHotjar() {
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:6388039,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (localStorage.getItem('cookieConsent') === 'accepted') {
+        loadHotjar();
+        return;
+    }
+
+    const banner = document.createElement('div');
+    banner.id = 'cookie-banner';
+    banner.innerHTML =
+        "Diese Website verwendet Cookies zur Analyse. Durch Klick auf 'Akzeptieren' stimmst du der Nutzung zu. " +
+        "<button id='accept-cookies'>Akzeptieren</button>";
+
+    document.body.appendChild(banner);
+    banner.style.display = 'block';
+
+    const btn = banner.querySelector('#accept-cookies');
+    btn.addEventListener('click', () => {
+        localStorage.setItem('cookieConsent', 'accepted');
+        banner.remove();
+        loadHotjar();
+    });
+});

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -1,46 +1,51 @@
 function loadHotjar() {
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:6388039,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+  (function (h, o, t, j, a, r) {
+    h.hj =
+      h.hj ||
+      function () {
+        (h.hj.q = h.hj.q || []).push(arguments);
+      };
+    h._hjSettings = { hjid: 6388039, hjsv: 6 };
+    a = o.getElementsByTagName("head")[0];
+    r = o.createElement("script");
+    r.async = 1;
+    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+    a.appendChild(r);
+  })(window, document, "https://static.hotjar.com/c/hotjar-", ".js?sv=");
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-    const consent = localStorage.getItem('cookieConsent');
-    if (consent === 'accepted') {
-        loadHotjar();
-        return;
-    }
-    if (consent === 'declined') {
-        return;
-    }
+document.addEventListener("DOMContentLoaded", () => {
+  const consent = localStorage.getItem("cookieConsent");
+  if (consent === "accepted") {
+    loadHotjar();
+    return;
+  }
+  if (consent === "declined") {
+    return;
+  }
 
-    const banner = document.createElement('div');
-    banner.id = 'cookie-banner';
-    banner.innerHTML =
-        "Diese Website verwendet Cookies zur Analyse. Durch Klick auf 'Akzeptieren' stimmst du der Nutzung zu." +
-        "<div class='cookie-buttons'>" +
-        "<button id='accept-cookies'>Akzeptieren</button>" +
-        "<button id='decline-cookies'>Ablehnen</button>" +
-        "</div>";
+  const banner = document.createElement("div");
+  banner.id = "cookie-banner";
+  banner.innerHTML =
+    "Diese Website verwendet Cookies zur Analyse. Durch Klick auf 'Akzeptieren' stimmst du der Nutzung zu." +
+    "<div class='cookie-buttons'>" +
+    "<button id='accept-cookies'>Akzeptieren</button>" +
+    "<button id='decline-cookies'>Ablehnen</button>" +
+    "</div>";
 
-    document.body.appendChild(banner);
-    banner.style.display = 'block';
+  document.body.appendChild(banner);
+  banner.style.display = "none";
 
-    const acceptBtn = banner.querySelector('#accept-cookies');
-    const declineBtn = banner.querySelector('#decline-cookies');
-    acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookieConsent', 'accepted');
-        banner.remove();
-        loadHotjar();
-    });
+  const acceptBtn = banner.querySelector("#accept-cookies");
+  const declineBtn = banner.querySelector("#decline-cookies");
+  acceptBtn.addEventListener("click", () => {
+    localStorage.setItem("cookieConsent", "accepted");
+    banner.remove();
+    loadHotjar();
+  });
 
-    declineBtn.addEventListener('click', () => {
-        localStorage.setItem('cookieConsent', 'declined');
-        banner.remove();
-    });
+  declineBtn.addEventListener("click", () => {
+    localStorage.setItem("cookieConsent", "declined");
+    banner.remove();
+  });
 });

--- a/lang/lang.json
+++ b/lang/lang.json
@@ -894,8 +894,8 @@
     "en": "Information according to § 5 TMG"
   },
   "imprint_section1_text": {
-    "de": "Tim Schedlbauer<br><br>Flandernstraße 146<br><br>73732 Esslingen am Neckar",
-    "en": "Tim Schedlbauer<br><br>Flandernstraße 146<br><br>73732 Esslingen am Neckar"
+    "de": "Tim Schedlbauer,  Flandernstraße 146, 73732 Esslingen am Neckar",
+    "en": "Tim Schedlbauer, Flandernstraße 146, 73732 Esslingen am Neckar"
   },
   "imprint_section2_title": {
     "de": "Kontakt",
@@ -910,8 +910,8 @@
     "en": "Responsible for content in accordance with § 55 para. 2 RStV:"
   },
   "imprint_section3_text": {
-    "de": "Tim Schedlbauer<br><br>Anschrift wie oben",
-    "en": "Tim Schedlbauer<br><br>Address as above"
+    "de": "Tim Schedlbauer, Anschrift wie oben",
+    "en": "Tim Schedlbauer, Address as above"
   },
   "privacy_section1_title": {
     "de": "Allgemeines",

--- a/privacy.html
+++ b/privacy.html
@@ -15,8 +15,10 @@
       href="https://fonts.googleapis.com/css?family=Comfortaa:200,400,500,700&display=swap"
       rel="stylesheet"
     />
+
   </head>
   <body>
+
     <main>
       <div class="smooth-wrapper" id="luxy"></div>
     </main>
@@ -32,5 +34,6 @@
         });
       }
     </script>
+    <script src="js/cookie-consent.js"></script>
   </body>
 </html>

--- a/project1.html
+++ b/project1.html
@@ -15,8 +15,10 @@
       href="https://fonts.googleapis.com/css?family=Comfortaa:200,400,500,700&display=swap"
       rel="stylesheet"
     />
+
   </head>
   <body>
+
     <main>
       <div class="smooth-wrapper" id="luxy"></div>
     </main>
@@ -32,5 +34,6 @@
         });
       }
     </script>
+    <script src="js/cookie-consent.js"></script>
   </body>
 </html>

--- a/project2.html
+++ b/project2.html
@@ -15,8 +15,10 @@
       href="https://fonts.googleapis.com/css?family=Comfortaa:200,400,500,700&display=swap"
       rel="stylesheet"
     />
+
   </head>
   <body>
+
     <main>
       <div class="smooth-wrapper" id="luxy"></div>
     </main>
@@ -32,5 +34,6 @@
         });
       }
     </script>
+    <script src="js/cookie-consent.js"></script>
   </body>
 </html>

--- a/project3.html
+++ b/project3.html
@@ -15,8 +15,10 @@
       href="https://fonts.googleapis.com/css?family=Comfortaa:200,400,500,700&display=swap"
       rel="stylesheet"
     />
+
   </head>
   <body>
+
     <main>
       <div class="smooth-wrapper" id="luxy"></div>
     </main>
@@ -32,5 +34,6 @@
         });
       }
     </script>
+    <script src="js/cookie-consent.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move cookie banner styles to `styles.css`
- create new `cookie-consent.js` module to inject banner and load Hotjar
- include the new script on every HTML page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883a63603488332be0677432597937b