### PR TITLE
Remove .html from hyperlinks

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -6,7 +6,7 @@
     "tags": ["UI,", "UX"],
     "titleKey": "project1_title",
     "descKey": "project1_desc",
-    "link": "project1.html",
+      "link": "project1",
     "flag": "project_flag_1",
     "btnLink": "view"
   },
@@ -17,7 +17,7 @@
     "tags": ["UI,", "UX,", "Game Design,", "3D,", "PM"],
     "titleKey": "project2_title",
     "descKey": "project2_desc",
-    "link": "project2.html",
+      "link": "project2",
     "flag": "project_flag_1",
     "btnLink": "view"
   },
@@ -28,7 +28,7 @@
     "tags": ["UI,", "UX,", "3D,", "PM"],
     "titleKey": "project3_title",
     "descKey": "project3_desc",
-    "link": "project3.html",
+      "link": "project3",
     "flag": "project_flag_1",
     "btnLink": "view"
   },
@@ -39,7 +39,7 @@
     "tags": ["UI,", "UX,", "Game Design,", "3D,", "Code"],
     "titleKey": "project4_title",
     "descKey": "project4_desc",
-    "link": "archive.html",
+      "link": "archive",
     "btnLink": "view"
   }
 ]

--- a/footer.html
+++ b/footer.html
@@ -31,8 +31,8 @@
     <div class="footer-bar-wrapper">
       <span class="footer-left">© Tim Schedlbauer</span>
       <span class="footer-right"
-        ><a class="nav-link" href="imprint.html" data-i18n="imprint"></a> |
-        <a class="nav-link" href="privacy.html" data-i18n="privacypolicy"></a
+        ><a class="nav-link" href="imprint" data-i18n="imprint"></a> |
+        <a class="nav-link" href="privacy" data-i18n="privacypolicy"></a
       ></span>
     </div>
   </div>

--- a/header.html
+++ b/header.html
@@ -1,14 +1,14 @@
 <header class="fade-top">
   <nav>
-    <a class="nav-brand" href="index.html">
+  <a class="nav-brand" href="index">
       <div class="logo"><img src="./assets/images/logo/Logo.svg" alt="Tim Schedlbauer Logo" /></div>
       <div class="link">Tim <br />Schedlbauer</div>
     </a>
     <button class="burger" id="burger-toggle" data-i18n="menu_toggle" data-i18n-attr="aria-label">&#9776;</button>
     <div class="nav-menu" id="nav-menu">
-      <a class="nav-link js-to-projects" href="index.html#projects" data-i18n="projects"></a>
-      <a class="nav-link" href="about.html" data-i18n="about"></a>
-      <a class="nav-link js-to-contact" href="index.html#contact" data-i18n="contact"></a>
+      <a class="nav-link js-to-projects" href="index#projects" data-i18n="projects"></a>
+      <a class="nav-link" href="about" data-i18n="about"></a>
+      <a class="nav-link js-to-contact" href="index#contact" data-i18n="contact"></a>
       <button id="lang-toggle" class="lang-btn" aria-label="Sprache wechseln">
         <span class="lang-option" data-lang="de">DE</span> /
         <span class="lang-option" data-lang="en">EN</span>

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
             </div>
             <button
               data-i18n="about"
-              onclick="window.location.href='about.html'"
+              onclick="window.location.href='about'"
             ></button>
           </div>
         </div>

--- a/js/footer.js
+++ b/js/footer.js
@@ -2,7 +2,7 @@ import { setLanguage, currentLang } from "./i18n.js";
 
 export async function loadFooter() {
   try {
-    const res = await fetch("footer.html");
+    const res = await fetch("footer");
     const html = await res.text();
     const temp = document.createElement("div");
     temp.innerHTML = html.trim();

--- a/js/header.js
+++ b/js/header.js
@@ -1,7 +1,7 @@
 export async function loadHeader(options = {}) {
   const { transparent = false, indexPage = false } = options;
   try {
-    const res = await fetch('header.html');
+    const res = await fetch('header');
     const html = await res.text();
     const temp = document.createElement('div');
     temp.innerHTML = html.trim();
@@ -9,7 +9,7 @@ export async function loadHeader(options = {}) {
     if (transparent) header.classList.add('transparent');
     if (indexPage) {
       const brand = header.querySelector('.nav-brand');
-      brand?.setAttribute('href', 'index.html#home');
+      brand?.setAttribute('href', 'index#home');
       const projects = header.querySelector('.js-to-projects');
       projects?.removeAttribute('href');
       const contact = header.querySelector('.js-to-contact');

--- a/js/project1.js
+++ b/js/project1.js
@@ -91,8 +91,8 @@ function renderSections() {
   ];
 
   const urls = [
-    { title: "project2_title", href: "project2.html" },
-    { title: "project3_title", href: "project3.html" },
+  { title: "project2_title", href: "project2" },
+  { title: "project3_title", href: "project3" },
   ];
 
   const sections = [

--- a/js/project2.js
+++ b/js/project2.js
@@ -128,8 +128,8 @@ function renderSections() {
   ];
 
   const urls = [
-    { title: "project1_title", href: "project1.html" },
-    { title: "project3_title", href: "project3.html" },
+  { title: "project1_title", href: "project1" },
+  { title: "project3_title", href: "project3" },
   ];
 
   const sections = [

--- a/js/project3.js
+++ b/js/project3.js
@@ -126,8 +126,8 @@ function renderSections() {
   ];
 
   const urls = [
-    { title: "project1_title", href: "project1.html" },
-    { title: "project2_title", href: "project2.html" },
+  { title: "project1_title", href: "project1" },
+  { title: "project2_title", href: "project2" },
   ];
 
   const sections = [


### PR DESCRIPTION
## Summary
- drop `.html` from navigation links
- update JS modules that fetch or link to html pages
- update project links in JSON

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6884ab17c3a88332b18456a97738f836