### PR TITLE
Add path-based language handling and /en rewriting

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,5 @@
 RewriteEngine On
+RewriteRule ^en/?$ /index.html [L]
+RewriteRule ^en/(.*)$ $1 [L]
 RewriteCond %{REQUEST_FILENAME}.html -f
 RewriteRule ^([^/]+)$ $1.html [L]

--- a/js/about.js
+++ b/js/about.js
@@ -3,6 +3,7 @@ import {
   currentLang,
   initLangToggle,
   getTranslation,
+  getInitialLanguage,
 } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { createTwoColumnSection } from "./layout.js";
@@ -12,7 +13,7 @@ import { loadFooter } from "./footer.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
-  await setLanguage(localStorage.getItem("lang") || "de");
+  await setLanguage(getInitialLanguage());
 
   initLangToggle();
 

--- a/js/archive.js
+++ b/js/archive.js
@@ -1,4 +1,4 @@
-import { setLanguage, initLangToggle, currentLang } from "./i18n.js";
+import { setLanguage, initLangToggle, getInitialLanguage } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
 import { loadHeader } from "./header.js";
@@ -6,7 +6,7 @@ import { loadFooter } from "./footer.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
-  await setLanguage(localStorage.getItem("lang") || "de");
+  await setLanguage(getInitialLanguage());
 
   initLangToggle();
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -23,7 +23,7 @@ async function loadTranslations() {
     .then((json) => {
       translations = json;
       return translations;
-    });
+  });
   return translationsPromise;
 }
 
@@ -32,6 +32,27 @@ function updateLangButtonUI() {
     const lang = el.getAttribute("data-lang");
     el.classList.toggle("active", lang === currentLang);
   });
+}
+
+export function getLangFromPath() {
+  return window.location.pathname.startsWith("/en") ? "en" : "de";
+}
+
+export function syncPathWithLanguage(lang = currentLang) {
+  const path = window.location.pathname;
+  const isEnPath = path.startsWith("/en");
+  if (lang === "en" && !isEnPath) {
+    const newPath = "/en" + (path === "/" ? "/" : path);
+    window.history.replaceState(null, "", newPath);
+  } else if (lang === "de" && isEnPath) {
+    const newPath = path.replace(/^\/en/, "") || "/";
+    window.history.replaceState(null, "", newPath);
+  }
+}
+
+export function getInitialLanguage() {
+  if (getLangFromPath() === "en") return "en";
+  return localStorage.getItem("lang") || "de";
 }
 
 export async function setLanguage(lang) {
@@ -59,6 +80,8 @@ export async function setLanguage(lang) {
 
   localStorage.setItem("lang", lang);
   updateLangButtonUI();
+  document.documentElement.setAttribute("lang", lang);
+  syncPathWithLanguage(lang);
 }
 
 export function initLangToggle(callback) {

--- a/js/imprint.js
+++ b/js/imprint.js
@@ -3,6 +3,7 @@ import {
   currentLang,
   initLangToggle,
   getTranslation,
+  getInitialLanguage,
 } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
@@ -12,7 +13,7 @@ import { createTwoColumnSection } from "./layout.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
-  await setLanguage(localStorage.getItem("lang") || "de");
+  await setLanguage(getInitialLanguage());
 
   initLangToggle();
   initNav();

--- a/js/index.js
+++ b/js/index.js
@@ -4,6 +4,7 @@ import {
   translations,
   initLangToggle,
   getTranslation,
+  getInitialLanguage,
 } from "./i18n.js";
 import {
   initNav,
@@ -16,7 +17,7 @@ import { loadFooter } from "./footer.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader({ transparent: true, indexPage: true });
-  await setLanguage(localStorage.getItem("lang") || "de");
+  await setLanguage(getInitialLanguage());
 
   initLangToggle();
 

--- a/js/privacy.js
+++ b/js/privacy.js
@@ -3,6 +3,7 @@ import {
   currentLang,
   initLangToggle,
   getTranslation,
+  getInitialLanguage,
 } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
@@ -12,7 +13,7 @@ import { createTwoColumnSection } from "./layout.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
-  await setLanguage(localStorage.getItem("lang") || "de");
+  await setLanguage(getInitialLanguage());
 
   initLangToggle();
   initNav();

--- a/js/project1.js
+++ b/js/project1.js
@@ -3,6 +3,7 @@ import {
   currentLang,
   initLangToggle,
   getTranslation,
+  getInitialLanguage,
 } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
@@ -20,7 +21,7 @@ import { convertYouTubeUrl } from "./youtubeUtils.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
-  await setLanguage(localStorage.getItem("lang") || "de");
+  await setLanguage(getInitialLanguage());
 
   initLangToggle();
   initNav();

--- a/js/project2.js
+++ b/js/project2.js
@@ -3,6 +3,7 @@ import {
   currentLang,
   initLangToggle,
   getTranslation,
+  getInitialLanguage,
 } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
@@ -20,7 +21,7 @@ import { convertYouTubeUrl } from "./youtubeUtils.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
-  await setLanguage(localStorage.getItem("lang") || "de");
+  await setLanguage(getInitialLanguage());
 
   initLangToggle();
   initNav();

--- a/js/project3.js
+++ b/js/project3.js
@@ -3,6 +3,7 @@ import {
   currentLang,
   initLangToggle,
   getTranslation,
+  getInitialLanguage,
 } from "./i18n.js";
 import { initNav } from "./nav.js";
 import { initFadeAnimations } from "./animations.js";
@@ -20,7 +21,7 @@ import { convertYouTubeUrl } from "./youtubeUtils.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadHeader();
-  await setLanguage(localStorage.getItem("lang") || "de");
+  await setLanguage(getInitialLanguage());
 
   initLangToggle();
   initNav();


### PR DESCRIPTION
## Summary
- detect language from `/en` path and keep URLs in sync when toggling
- initialize page language from URL and update path consistently across pages
- add Apache rewrites to serve English URLs without duplicating files

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6893432aa9608332854487aa7faab66e