### PR TITLE
Add Express server for static portfolio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log*

--- a/404.html
+++ b/404.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>404 – Seite nicht gefunden</title>
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body>
+    <main style="padding:2rem;text-align:center;">
+      <h1>404 – Seite nicht gefunden</h1>
+      <p>Die angeforderte Seite konnte nicht gefunden werden.</p>
+      <p><a href="/">Zurück zur Startseite</a></p>
+    </main>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "portfolio",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = 3000;
+const ROOT = __dirname;
+
+// Support optional /en prefix
+app.use((req, res, next) => {
+  if (req.url === '/en') {
+    req.url = '/';
+  } else if (req.url.startsWith('/en/')) {
+    req.url = req.url.slice(3); // remove /en
+  }
+  next();
+});
+
+// Serve static files and map URLs without extension to .html files
+app.use(express.static(ROOT, {
+  extensions: ['html']
+}));
+
+// Fallback to custom 404 page
+app.use((req, res) => {
+  res.status(404).sendFile(path.join(ROOT, '404.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express server with extensionless routing, `/en` prefix support and custom 404 page
- include simple 404 page and package.json with start/test scripts

## Testing
- `npm install express` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `node server.js` *(fails: Cannot find module 'express')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893510d87988332b27d985ee6ca1235