### PR TITLE
feat: clean routing and 404 handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,20 +11,12 @@ const PORT = 3000;
 // Statisches Hosting + automatische .html Erweiterung
 app.use(express.static(__dirname, { extensions: ["html"] }));
 
-// Handle /en/* URLs -> entferne /en und bediene lokale HTML-Datei
-app.use("/en", (req, res, next) => {
-  let page = req.path === "/" ? "/index" : req.path;
-  res.sendFile(path.join(__dirname, page + ".html"), (err) => {
-    if (err) next();
-  });
-});
+// "en"-Präfix auf die gleichen Dateien wie ohne Präfix abbilden
+app.use("/en", express.static(__dirname, { extensions: ["html"] }));
 
-// Fallback: URLs ohne .html bedienen
-app.get("*", (req, res, next) => {
-  let page = req.path === "/" ? "/index" : req.path;
-  res.sendFile(path.join(__dirname, page + ".html"), (err) => {
-    if (err) next();
-  });
+// 404-Fallback auf benutzerdefinierte Seite
+app.use((req, res) => {
+  res.status(404).type("html").sendFile(path.join(__dirname, "404.html"));
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- serve HTML files without extension using express static
- map `/en` prefixed URLs to the same static files
- return `404.html` with HTML content type when file is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935512d0888332a3e227aa6f49c88e